### PR TITLE
Add Windows venv setup instructions and ignore venv directory

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+venv/

--- a/python/README.md
+++ b/python/README.md
@@ -2,9 +2,16 @@
 
 Create and activate a virtual environment first:
 
+On macOS/Linux:
 ```bash
 python3 -m venv venv
 source venv/bin/activate
+```
+
+On Windows:
+```bash
+python -m venv venv
+venv\Scripts\activate
 ```
 
 Then install dependencies:


### PR DESCRIPTION
 Add Windows virtual environment setup instructions to the Python MCP server README and add the venv/ to .gitignore