### PR TITLE
Adds example fhir context scopes to the Python  server

### DIFF
--- a/python/mcp_instance.py
+++ b/python/mcp_instance.py
@@ -9,7 +9,16 @@ _original_get_capabilities = mcp._mcp_server.get_capabilities
 
 def _patched_get_capabilities(notification_options, experimental_capabilities):
     caps = _original_get_capabilities(notification_options, experimental_capabilities)
-    caps.model_extra["extensions"] = {"ai.promptopinion/fhir-context": {}}
+    caps.model_extra["extensions"] = {
+        "ai.promptopinion/fhir-context": {
+            "scopes": [
+                {"name": "patient/Patient.rs", "required": True},
+                {"name": "patient/Observation.rs"},
+                {"name": "patient/MedicationStatement.rs"},
+                {"name": "patient/Condition.rs"},
+            ]
+        }
+    }
     return caps
 
 mcp._mcp_server.get_capabilities = _patched_get_capabilities


### PR DESCRIPTION
### Description

Adds the same example fhir context scopes to the  Python server that were added to the Typescript and .Net servers